### PR TITLE
对#25 的处理以及其它小改动

### DIFF
--- a/Custom.xaml
+++ b/Custom.xaml
@@ -49,7 +49,6 @@
 </local:MyCard>
 <local:MyCard Margin="0,0,0,12" Title="网页捷径" CanSwap="True" IsSwaped="True">
      <StackPanel Margin="20,40,20,15">
-          <!-- 尝试做了一下，输入网页，按按钮打开。这将会加入V0.0.5中。 -->
           <Grid>
                <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="3*" />
@@ -81,8 +80,7 @@
                          -->
                     <!--
                          <local:MyListItem Margin="-2,0,0,0" Logo="pack://application:,,,/images/Blocks/GrassPath.png" Title="MCBBS" Info="最大的我的世界《Minecraft》中文论坛" EventType="打开网页" EventData="https://www.mcbbs.net" Type="Clickable" />
-                    
-                         已寄
+                         已寄 R.I.P.
                     -->
                     <local:MyListItem Margin="-2,0,0,0" Logo="https://klpbbs.com/favicon.ico" Title="苦力怕BBS" Info="最大的我的世界《Minecraft》基岩版（BE）中文资源、交流论坛之一" EventType="打开网页" EventData="https://klpbbs.com/" Type="Clickable" />
                     <local:MyListItem Margin="-2,0,0,0" Logo="https://www.minebbs.com/favicon.ico" Title="MineBBS" Info="以我的世界基岩版（MCBE）内容为主的Minecraft中文论坛。" EventType="打开网页" EventData="https://www.minebbs.com/" Type="Clickable" />

--- a/Custom.xaml
+++ b/Custom.xaml
@@ -62,7 +62,7 @@
                <StackPanel Margin="24,40,24,15">
                     <local:MyListItem Margin="-2,0,0,0" Logo="https://www.baidu.com/favicon.ico" Title="百度" Info="百度一下，你就知道" EventType="打开网页" EventData="https://www.baidu.com/" Type="Clickable" />
                     <local:MyListItem Margin="-2,0,0,0" Logo="https://cn.bing.com/favicon.ico" Title="Bing" Info="有求必应" EventType="打开网页" EventData="https://cn.bing.com/" Type="Clickable" />
-                    <local:MyListItem Margin="-2,0,0,0" Logo="https://www.bilibili.com/favicon.ico" Title="Bilibili" Info="哔哩哔哩 (゜-゜)つロ 干杯~" EventType="打开网页" EventData="https://www.bilibili.com/" Type="Clickable" />
+                    <local:MyListItem Margin="-2,0,0,0" Logo="https://static.hdslb.com/images/favicon.ico" Title="Bilibili" Info="哔哩哔哩 (゜-゜)つロ 干杯~" EventType="打开网页" EventData="https://www.bilibili.com/" Type="Clickable" />
                     <local:MyListItem Margin="-2,0,0,0" Logo="https://github.githubassets.com/favicon.ico" Title="GitHub" Info="Let's build from here" EventType="打开网页" EventData="https://github.com/" Type="Clickable" />
                     <local:MyListItem Margin="-2,0,0,0" Logo="https://static.zhihu.com/heifetz/favicon.ico" Title="知乎" Info="有问题，就会有答案" EventType="打开网页" EventData="https://www.zhihu.com/" Type="Clickable" />
                </StackPanel>

--- a/Custom.xaml
+++ b/Custom.xaml
@@ -28,7 +28,7 @@
                </Grid.ColumnDefinitions>
                <local:MyIconButton Grid.Column="1" LogoScale="1.2" Logo="M13.5,4A1.5,1.5 0 0,0 12,5.5A1.5,1.5 0 0,0 13.5,7A1.5,1.5 0 0,0 15,5.5A1.5,1.5 0 0,0 13.5,4M13.14,8.77C11.95,8.87 8.7,11.46 8.7,11.46C8.5,11.61 8.56,11.6 8.72,11.88C8.88,12.15 8.86,12.17 9.05,12.04C9.25,11.91 9.58,11.7 10.13,11.36C12.25,10 10.47,13.14 9.56,18.43C9.2,21.05 11.56,19.7 12.17,19.3C12.77,18.91 14.38,17.8 14.54,17.69C14.76,17.54 14.6,17.42 14.43,17.17C14.31,17 14.19,17.12 14.19,17.12C13.54,17.55 12.35,18.45 12.19,17.88C12,17.31 13.22,13.4 13.89,10.71C14,10.07 14.3,8.67 13.14,8.77Z"
                     Height="21" Margin="0,5,0,0" ToolTip="关于作者"
-                    EventData="关于作者|我是MFn233，一个妄图写出完美代码的程序员，该主页目前由我独立完成，并在GitHub上开源。欢迎你前往仓库为我的项目提issue\n\n如果你真的很希望更多地了解我，欢迎访问我的网站: mfn233.github.io\n\n鸣谢(排名不分先后): \n\nMCSteve123(GitHub)提交大量pull request\nJingHai-Lingyun(GitHub)提供修复建议与改进建议\nAd_closeNN(GitHub)提交大量pull request\nwuliaodexiaoluo(GitHub)提供改进建议\nSIPC(sipc.ink)帮助将主页文件挂载于云服务器\n\n©MFn233 2023/7/22" EventType="弹出窗口" VerticalAlignment="Bottom"/>
+                    EventData="关于作者|我是MFn233，一个妄图写出完美代码的程序员，该主页目前由我独立完成，并在GitHub上开源。欢迎你前往仓库为我的项目提issue\n\n如果你真的很希望更多地了解我，欢迎访问我的网站: mfn233.github.io\n\n©MFn233 2023/7/22" EventType="弹出窗口" VerticalAlignment="Bottom"/>
                <local:MyIconButton Grid.Column="2" LogoScale="1.2" Logo="M256.455,8C322.724,8.119,382.892,34.233,427.314,76.685L463.029,40.97C478.149,25.851,504,36.559,504,57.941L504,192C504,205.255,493.255,216,480,216L345.941,216C324.559,216,313.851,190.149,328.97,175.029L370.72,133.279C339.856,104.38 299.919,88.372 257.49,88.006 165.092,87.208 87.207,161.983 88.0059999999999,257.448 88.764,348.009 162.184,424 256,424 297.127,424 335.997,409.322 366.629,382.444 371.372,378.283 378.535,378.536 382.997,382.997L422.659,422.659C427.531,427.531 427.29,435.474 422.177,440.092 378.202,479.813 319.926,504 256,504 119.034,504 8.001,392.967 8,256.002 7.999,119.193 119.646,7.755 256.455,8z"
                     Height="21" Margin="0,5,0,0"
                     ToolTip="点此刷新" EventType="刷新主页" VerticalAlignment="Bottom"/>
@@ -180,6 +180,14 @@
                <local:MyButton Grid.Column="0" Margin="0,0,10,0" Height="35" Text="更新日志" EventType="打开网页" 
                     EventData="https://github.com/MFn233/PCL-Mainpage/releases/latest" ToolTip="将前往GitHub查看最新版本的更新日志"/>
                <local:MyButton Grid.Column="1" Margin="0,0,0,0" Height="35" Text="项目仓库" EventType="打开网页" EventData="https://github.com/MFn233/PCL-Mainpage"/>
+          </Grid>
+          <Grid>
+               <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="1*"/>
+                    <ColumnDefinition Width="1*"/>
+               </Grid.ColumnDefinitions>
+               <local:MyButton Grid.Column="0" Margin="0,10,10,0" Height="35" Text="鸣谢" EventType="弹出窗口" 
+                    EventData="鸣谢（排名不分先后）|MCSteve123(GitHub)提交大量pull request\nJingHai-Lingyun(GitHub)提供修复建议与改进建议\nAd_closeNN(GitHub)提交大量pull request\nwuliaodexiaoluo(GitHub)提供改进建议\nSIPC(sipc.ink)帮助将主页文件挂载于云服务器" ToolTip="查看鸣谢（排名不分先后）"/>
           </Grid>
      </StackPanel>
 </local:MyCard>

--- a/Custom.xaml
+++ b/Custom.xaml
@@ -132,6 +132,8 @@
 </local:MyCard>
 <local:MyCard Margin="0,0,0,12" Title="更多" CanSwap="True" IsSwaped="True">
      <StackPanel Margin="24,40,24,15">
+          <local:MyListItem Margin="-2,0,0,6" Logo="https://zh.minecraft.wiki/favicon.ico" Title="【重要】中文MC Wiki迁移通知" Info="中文Minecraft Wiki现已迁移至zh.minecraft.wiki,请不要再访问Fandom的旧wiki!" EventType="打开网页" EventData="https://zh.minecraft.wiki/w/Minecraft_Wiki:%E8%BF%81%E7%A7%BB%E9%80%9A%E7%9F%A5" Type="Clickable" />
+          <local:MyListItem Margin="-2,0,0,12" Logo="https://static.zhihu.com/heifetz/favicon.ico" Title="【重要】国内最大我的世界社区MCBBS将关闭" Info="基本确定！国内最大我的世界社区mcbbs将关闭！" EventType="打开网页" EventData="https://zhuanlan.zhihu.com/p/683019909" Type="Clickable" />
           <Grid>
                <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1*" />
@@ -170,8 +172,6 @@
 </local:MyCard>
 <local:MyCard Margin="0,0,0,12" Title="关于" CanSwap="True" IsSwaped="True">
      <StackPanel Margin="24,40,24,15">
-          <local:MyListItem Margin="-2,0,0,6" Logo="https://zh.minecraft.wiki/favicon.ico" Title="【重要】中文MC Wiki迁移通知" Info="中文Minecraft Wiki现已迁移至zh.minecraft.wiki,请不要再访问Fandom的旧wiki!" EventType="打开网页" EventData="https://zh.minecraft.wiki/w/Minecraft_Wiki:%E8%BF%81%E7%A7%BB%E9%80%9A%E7%9F%A5" Type="Clickable" />
-          <local:MyListItem Margin="-2,0,0,12" Logo="https://static.zhihu.com/heifetz/favicon.ico" Title="【重要】国内最大我的世界社区MCBBS将关闭" Info="基本确定！国内最大我的世界社区mcbbs将关闭！" EventType="打开网页" EventData="https://zhuanlan.zhihu.com/p/683019909" Type="Clickable" />
           <Grid>
                <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1*" />

--- a/Custom.xaml
+++ b/Custom.xaml
@@ -97,6 +97,7 @@
 </local:MyCard>
 <local:MyCard Margin="0,0,0,12" Title="启动器工具" CanSwap="True" IsSwaped="True">
      <StackPanel Margin="24,40,24,15">
+          <local:MyHint IsWarn="False" Text="此处所有功能均为启动器自带，出问题请上报至PCL2仓库" Margin="0,0,0,5"/>
           <Grid>
                <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1*" />


### PR DESCRIPTION
# 概述
- 完成了#25 的内容
- 其它小更改

# 详情
1. 添加启动器工具提示条
2. 将两个重要通知转移至“更多”以符合实际
3. 将鸣谢页面分离至“关于”
4. 更改了B站图标获取网址（不知道为啥，原链接现在好像404？）
5. 对注释的合理修改

---
**又及：请自行修改“关于作者”的版权信息，这玩意实在太老了，23年7月的，~我不敢随便改，毕竟版权是作者的~**